### PR TITLE
Change the default model to the first one with data upon loading

### DIFF
--- a/frontend/src/hooks/useModelData.ts
+++ b/frontend/src/hooks/useModelData.ts
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import {
 	FALLBACK_MODEL_CARDS,
 	fetchModelCards,
+	resolveRequestVariable,
 } from "../services/modelCardService";
+import { fetchNutsData } from "../services/nutsDataService";
 import type { Model } from "../types/model";
 
 export interface UseModelDataReturn {
@@ -16,6 +18,7 @@ export const useModelData = (
 	setSelectedModel: (model: string) => void,
 ): UseModelDataReturn => {
 	const [models, setModels] = useState<Model[]>([]);
+	const [initialSelection] = useState(selectedModel);
 	const [modelMetadataLoading, setModelMetadataLoading] = useState(true);
 	const [modelMetadataError, setModelMetadataError] = useState<string | null>(
 		null,
@@ -31,25 +34,41 @@ export const useModelData = (
 				if (loadedModels.length === 0) {
 					throw new Error("No model metadata found in artifact payload");
 				}
+				let defaultModel = loadedModels[0].id; // fallback incase no model has any data
+				if (!initialSelection) {
+					for (const model of loadedModels) {
+						try {
+							const data = await fetchNutsData(
+								2025,
+								7,
+								resolveRequestVariable(model),
+								"NUTS3",
+							);
+							if (Object.keys(data).length > 0) {
+								defaultModel = model.id; // assign default model for later use in setSelectedModel
+								break; // stop checking for other models, leave the for loop
+							}
+						} catch (error) {
+							console.debug(`No startup data for ${model.id}:`, error);
+						}
+					} // finally set to the model which had some data.
+					setSelectedModel(defaultModel);
+				}
 				setModels(loadedModels);
 			} catch (error) {
 				console.error("Error loading model cards:", error);
 				setModelMetadataError("Failed to load models from metadata artifact");
 				setModels(FALLBACK_MODEL_CARDS);
+				if (!initialSelection) {
+					setSelectedModel(FALLBACK_MODEL_CARDS[0].id);
+				}
 			} finally {
 				setModelMetadataLoading(false);
 			}
 		};
 
 		loadModels();
-	}, []);
-
-	// Set the first model as default once models are loaded
-	useEffect(() => {
-		if (!selectedModel && models.length > 0) {
-			setSelectedModel(models[0].id);
-		}
-	}, [models, selectedModel, setSelectedModel]);
+	}, [initialSelection, setSelectedModel]);
 
 	return {
 		models,

--- a/frontend/tests/setup/apiMocks.ts
+++ b/frontend/tests/setup/apiMocks.ts
@@ -74,4 +74,20 @@ export async function setupApiMocksWithFs(page: Page) {
 
 		await mock2025Handler(route);
 	});
+
+	await page.route("**/api/nuts_data**", async (route) => {
+		const variable = new URL(route.request().url()).searchParams.get(
+			"requested_variable_type",
+		);
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify(
+				variable === "R0" || variable === "r0_estimate"
+					? { result: { DE111: 0.1 } } // for R0, aka for WNV-R0, the main model used in Playwright, return one fake datapoint
+					: { error: "Missing variable type for requested time point." }, // For other models, e.g. AA model, return no data
+				// due to changes to useModelData.ts cycling through models from the first until it finds one with > 0 data points
+			),
+		});
+	});
 }


### PR DESCRIPTION
To avoid changes to the model cards or order affecting and causing a "No data for this model" dialog to appear even if another model has data.